### PR TITLE
feat: Add PicklePersistence for data persistence

### DIFF
--- a/main.py
+++ b/main.py
@@ -30,7 +30,7 @@ import uvicorn
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, ReplyKeyboardRemove, Update
 from telegram.ext import (
     Application, ApplicationBuilder, CallbackQueryHandler, CommandHandler, ContextTypes,
-    ConversationHandler, MessageHandler, filters, JobQueue
+    ConversationHandler, MessageHandler, filters, JobQueue, PicklePersistence
 )
 from telegram.error import BadRequest, NetworkError
 
@@ -947,7 +947,8 @@ async def post_shutdown(app: Application):
 async def lifespan(app: FastAPI):
     global tg_app, bot
     try:
-        builder = ApplicationBuilder().token(TOKEN).post_init(post_init).post_shutdown(post_shutdown)
+        persistence = PicklePersistence(filepath="bazarino_persistence.pickle")
+        builder = ApplicationBuilder().token(TOKEN).persistence(persistence).post_init(post_init).post_shutdown(post_shutdown)
         tg_app = builder.build()
         bot = tg_app.bot
         await tg_app.initialize()


### PR DESCRIPTION
This commit introduces `PicklePersistence` to the Telegram bot application.

Previously, your data (such as shopping carts and order information) was stored in memory, leading to data loss upon application restart. This change addresses the issue by persisting `user_data`, `chat_data`, and `bot_data` to a file named `bazarino_persistence.pickle`.

This ensures that your sessions are maintained across restarts, significantly improving the bot's reliability and your experience.